### PR TITLE
Add DeveloperName fields

### DIFF
--- a/src/data/firefox.yml
+++ b/src/data/firefox.yml
@@ -11,6 +11,7 @@ Description:
       companies. From privacy tools to tracking protection, you’re in charge
       of who sees what.</p>
 ProjectLicense: MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+
+DeveloperName: Mozilla Corporation
 Categories:
  - Network
  - WebBrowser

--- a/src/data/steam.yml
+++ b/src/data/steam.yml
@@ -11,6 +11,7 @@ Description:
       There is some free software available, but for the most part the content
       delivered is non-free.</p>
 ProjectLicense: CC0-1.0
+DeveloperName: Valve Corporation
 Categories:
 - Game
 Keywords:

--- a/src/data/thunderbird.yml
+++ b/src/data/thunderbird.yml
@@ -10,6 +10,7 @@ Description:
     <p>Thunderbird is a free email application that’s easy to set up and
       customize - and it’s loaded with great features!</p>
 ProjectLicense: MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+
+DeveloperName: Mozilla Foundation
 Categories:
  - Network
 Keywords:


### PR DESCRIPTION
We aren't currently including `DeveloperName` Fields. This looks weird in Pop_Shop as the Developer will be listed as "The APPNAME Developers"

Most of the general public know that "The Firefox Developers" are called Mozilla